### PR TITLE
Update Node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ outputs:
   messageID:
     description: "The AWS SNS Message ID"
 runs:
-  using: "node12"
+  using: "node16"
   main: "src/index.js"
 branding:
   color: "orange"


### PR DESCRIPTION
Updates to Node 16, now that Node 12 actions have been deprecated. See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/